### PR TITLE
Add OsintCat to Data Breached OSINT section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,7 @@ Politic and Geopolitic Archive
 - [Hudson Rock Cybercrime Intelligence Free Tools](https://www.hudsonrock.com/threat-intelligence-cybercrime-tools)
 - [dehashed](https://dehashed.com/)
 - [breach house](https://breach.house/all_stealers)
+- [OsintCat](https://www.osintcat.net/) Look up emails, usernames, and phone numbers in breach databases — clean results, no noise
 
 # Crack Jurnals
 


### PR DESCRIPTION
Adds OsintCat (https://www.osintcat.net/) to the Data Breached OSINT section.

OsintCat is a breach search tool for looking up emails, usernames, and phone numbers across leaked databases. Fast and reliable — a practical addition to any OSINT cheat sheet.