### PR TITLE
Add PeekVault to Twitter OSINT resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2159,6 +2159,7 @@ Note is for investigator like search scandal, deepfake porn or blackmail, red di
 - [Twitter Archive](https://github.com/humandecoded/twayback)
 - [History Twitter](https://memory.lol/app/)
 - [Wayback Twitter](https://waybacktweets.streamlit.app/)
+- [PeekVault](https://peekvault.com/) Search public X/Twitter captures from the Internet Archive CDX index, preview archived snapshots, and export results.
 - [Twitter BOT](https://botometer.osome.iu.edu/)
 - [botometer Twitter dataset](https://botometer.osome.iu.edu/bot-repository/datasets.html)
 - [Treverse](https://github.com/paulgb/Treeverse/blob/master/README.md?utm_content=buffer33d48&utm_medium=social&utm_source=twitter.com&utm_campaign=buffer#readme)


### PR DESCRIPTION
Hi, thanks for maintaining this OSINT resource list.

This PR adds [PeekVault](https://peekvault.com/) to the Twitter resources section. It helps search public X/Twitter captures using the Internet Archive CDX index, preview archived snapshots, and export results for review or documentation.

I placed it near the existing archive / Wayback-related tools.