### PR TITLE
Add IGDetective to Instagram tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -2061,6 +2061,7 @@ Note is for investigator like search scandal, deepfake porn or blackmail, red di
 - [storiesig picuki viewer](https://storiesig.info/en/picuki/)
 - [hostagram](https://github.com/banaxou/hostagram)
 - [instasploit](https://gitlab.com/anezatra-katedram/instasploit)
+- [IGDetective](https://www.igdetective.com) Track public Instagram accounts without login — recent follows/unfollows in chronological order, top interactions, and anonymous story viewing
 
 # Threads
 


### PR DESCRIPTION
Adds **IGDetective** (https://www.igdetective.com) to the `# Instagram` section.

**What it is / how to use:** A browser-based tool (no install, no scripts, no Instagram login). Enter any public Instagram username and it shows who the account recently followed/unfollowed in chronological order, who it interacts with most, and lets you view public Stories anonymously. There's also an AI assistant that summarizes a profile's recent public activity.

**OSINT use:** Useful SOCMINT signals for mapping a public account's connections and recent activity without leaving a footprint on the target. Works on public data only.

Appended to the end of the Instagram list, matching the existing `- [name](url) description` format.

**Disclosure:** I work on IGDetective — flagging that this is a self-promotional submission. Happy to adjust the wording or remove it if it doesn't fit.
