### PR TITLE
Add IPASIS to IP Addresses section

### DIFF
--- a/README.md
+++ b/README.md
@@ -944,7 +944,7 @@ This tools can show your ip address isp provider
 - [Ip 2 location](https://www.ip2location.com/)
 This tools can show your ip address isp provider and geo location  
 - [unwiredlabs](https://unwiredlabs.com/products) Dataset about IP around world 
-- [IPASIS](https://ipasis.com/) Real-time bot detection and fraud prevention API with IP reputation, VPN/proxy/Tor detection, and email validation in a single call
+- [IPASIS](https://ipasis.com/) Real-time bot detection and fraud prevention API. Returns risk score (0-100), VPN/proxy/Tor/residential proxy flags, IP reputation, email validation (disposable/free/domain age), and fraud signals — all from a single API call with IP + email input. Sub-20ms response. Free tier: 100 req/day
 
 # Wireless Network
 

--- a/README.md
+++ b/README.md
@@ -944,6 +944,7 @@ This tools can show your ip address isp provider
 - [Ip 2 location](https://www.ip2location.com/)
 This tools can show your ip address isp provider and geo location  
 - [unwiredlabs](https://unwiredlabs.com/products) Dataset about IP around world 
+- [IPASIS](https://ipasis.com/) Real-time bot detection and fraud prevention API with IP reputation, VPN/proxy/Tor detection, and email validation in a single call
 
 # Wireless Network
 


### PR DESCRIPTION
Added [IPASIS](https://ipasis.com/) to the **IP Addresses** section.

IPASIS is a real-time bot detection and fraud prevention API that provides IP reputation scoring, VPN/proxy/Tor detection, and email validation in a single API call. Similar to AbuseIPDB and IPQS (both already listed in this cheat sheet) but combines IP + email analysis into one request with sub-20ms response time.

Free tier available (100 requests/day, no credit card required).