### PR TITLE
Add Xquik to SOCMINT tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Automated tool by David Bombal
 - [Tinfoleak](https://github.com/vaguileradiaz/tinfoleak)
 - [Alfred](https://github.com/Alfredredbird/alfred)
 - [Blackbird](https://github.com/p1ngul1n0/blackbird)
+- [Xquik](https://xquik.com/) X/Twitter OSINT platform for tweet search, profile export, media download, monitoring, webhooks, REST API, and MCP access
 - [sociallinks](https://sociallinks.io/products/sl-crimewall)
 - [maigret](https://github.com/soxoj/maigret)
 - [social searcher](https://www.social-searcher.com/)


### PR DESCRIPTION
## Summary

Adds Xquik to the existing SOCMINT resource list. This keeps the contribution to one list entry, with no scripts or account material added.

## Validation

- `git diff --check`
- `curl -fsSL -o /dev/null -w "%{http_code} %{url_effective}\n" --max-time 20 https://xquik.com/` returned `200 https://xquik.com/en`

License note: this repository has no GitHub-detected license, so I kept the change to a small documentation catalog entry.
