### PR TITLE
Add Metadata Remover to EXIF resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ More : man exiftool (Run on your terminal)
 Site :
 
 - [Exiftool](https://exiftool.org/)
+- [Metadata Remover](https://metadataremover.ai/metadata-viewer) — Browser-local viewer for EXIF, GPS, XMP, IPTC, and supported AI metadata; no uploads or account required.
 - [List tagname](https://exiftool.org/TagNames/)
 - [List tagnme 2](https://metacpan.org/dist/Image-ExifTool/view/lib/Image/ExifTool/TagNames.pod)
 - [List tagname 3](https://manpages.org/imageexiftooltagnames/3)


### PR DESCRIPTION
Disclosure: I maintain [Metadata Remover](https://metadataremover.ai/metadata-viewer).

This adds one browser-local image metadata viewer to the existing EXIF Tool Command resource section. It reads EXIF, GPS, XMP, IPTC, and supported AI metadata from JPG, PNG, and WebP files without uploads or an account. The PR contains one factual list item.