### PR TITLE
Add CC.LA — free domain intelligence toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ Notes this is for surface web or clearnet site
 - [Check availabe domain tld list](https://tld-list.com/)
 - [check available domain](https://instantdomainsearch.com/)
 - [DomScan](https://domscan.net/tools/security) Domain intelligence for DNS, WHOIS/RDAP, TLS, subdomains, reputation, redirects, and typosquatting
+- [CC.LA](https://cc.la) Free domain intelligence for WHOIS/RDAP, DNS records, IP WHOIS, SSL certificates, name server history, and network diagnostics. No sign-up required.
 - [reverse google analytics](https://osint.sh/analytics/)
 - [reverse google adsense](https://osint.sh/adsense/)
 - [GAU getallurls](https://github.com/lc/gau)


### PR DESCRIPTION
Add [CC.LA](https://cc.la) next to DomScan in the domain section — free domain intelligence for WHOIS/RDAP, DNS records, IP WHOIS, SSL certificates, name server history, and network diagnostics. No sign-up required.