### PR TITLE
Add Offendersearch to Public Records

### DIFF
--- a/README.md
+++ b/README.md
@@ -1808,7 +1808,7 @@ If you has found the person phone number you can check at data breach, e wallet,
 
 - [Public Record](http://publicrecords.searchsystems.net)
 - [Crime Reports](http://www.crimereports.com)
-- [Offendersearch](https://offendersearch.app/) Search all 58 US state, territory & tribal sex offender registries (incl. NSOPW) in one query
+- [Offendersearch](https://offendersearch.app/) Search all 58 US sex offender registries — every US state, DC and the territories — in one query
 - [OONI](https://explorer.ooni.org/search?since=2025-05-02&until=2025-06-02&failure=false) Checking blocked site global
 - [Harvester](https://github.com/laramies/theHarvester)
 

--- a/README.md
+++ b/README.md
@@ -1808,6 +1808,7 @@ If you has found the person phone number you can check at data breach, e wallet,
 
 - [Public Record](http://publicrecords.searchsystems.net)
 - [Crime Reports](http://www.crimereports.com)
+- [Offendersearch](https://offendersearch.app/) Search all 58 US state, territory & tribal sex offender registries (incl. NSOPW) in one query
 - [OONI](https://explorer.ooni.org/search?since=2025-05-02&until=2025-06-02&failure=false) Checking blocked site global
 - [Harvester](https://github.com/laramies/theHarvester)
 


### PR DESCRIPTION
Adds Offendersearch under Public Records, beside the existing Crime Reports / Public Record entries. One query searches all 58 US state, territory and tribal sex-offender registries and returns scored results with a link to the official registry record behind each match. Free. https://offendersearch.app
